### PR TITLE
Content Expiry compatibility added via cms_config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+=========
+Changelog
+=========
+
+unreleased
+==========
+* feat: Add Content Expiry integration, allows filtering the Content Expiry Changelist AliasContents Content Type by site.

--- a/djangocms_alias/cms_config.py
+++ b/djangocms_alias/cms_config.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 from cms.app_base import CMSAppConfig
 
+from .helpers import content_expiry_site_alias_excluded_set
 from .models import AliasContent, AliasPlugin, copy_alias_content
 from .rendering import render_alias_content
 
@@ -50,3 +51,8 @@ class AliasCMSConfig(CMSAppConfig):
         internalsearch_config_list = [
             AliasContentConfig,
         ]
+
+    # Content Expiry changelist filer results by site
+    djangocms_content_expiry_changelist_queryset_filters = [
+        content_expiry_site_alias_excluded_set
+    ]

--- a/djangocms_alias/helpers.py
+++ b/djangocms_alias/helpers.py
@@ -1,0 +1,39 @@
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.shortcuts import get_current_site
+from django.db.models import Q
+
+from djangocms_alias.models import AliasContent
+
+
+def _get_excluded_alias_site_list(site):
+    """
+    Get a list of Alias objects that cannot be viewed by the current site
+
+    :param site: A site object to query against
+    :return: A filtered list of alias objects
+    """
+    alias_exclusion_set = AliasContent._original_manager.exclude(Q(alias__site=site) | Q(alias__site__isnull=True))
+    alias_exclusion_set.select_related('alias')
+    return alias_exclusion_set.values_list('id', flat=True)
+
+
+def content_expiry_site_alias_excluded_set(queryset, request):
+    """
+    Filter ContentExpiry records to show only Alias objects available on a given site.
+    Model structure: Expiry->Version->Content->Alias->site
+
+    CAUTION: This helper is used by a third party (djangocms-content-expiry), change with caution.
+
+    :param site: A site object to query against
+    :param queryset: A queryset object of ContentExpiry records
+    :return: A filtered list of Content Expiry records minus any none site PageContent models
+    """
+    current_site = get_current_site(request)
+    alias_content_ctype = ContentType.objects.get_for_model(AliasContent)
+    alias_exclusion_set = _get_excluded_alias_site_list(current_site)
+
+    queryset = queryset.exclude(
+      version__content_type=alias_content_ctype, version__object_id__in=alias_exclusion_set
+    )
+
+    return queryset

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,6 @@ INSTALL_REQUIREMENTS = [
     'django-cms',
 ]
 
-TEST_REQUIRE = [
-    "djangocms_helper",
-    'djangocms-versioning',
-]
-
 setup(
     name='djangocms-alias',
     author='Divio AG',
@@ -48,11 +43,5 @@ setup(
     install_requires=INSTALL_REQUIREMENTS,
     packages=find_packages(),
     include_package_data=True,
-    zip_safe=False,
-    tests_require=TEST_REQUIRE,
     test_suite='test_settings.run',
-    dependency_links=[
-        'http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0',
-        'http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23',
-    ]
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,3 +6,4 @@ pyflakes>=2.1.1
 django-classy-tags<2.0.0
 django-sekizai<2.0.0
 django-parler<=2.1
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,97 @@
+import datetime
+
+from django.contrib.sites.models import Site
+from django.contrib.sites.shortcuts import get_current_site
+from django.test import override_settings, RequestFactory
+
+from cms.test_utils.testcases import CMSTestCase
+
+from djangocms_alias.models import Alias as AliasModel, AliasContent, Category
+from djangocms_alias.helpers import _get_excluded_alias_site_list
+from djangocms_alias.utils import is_versioning_enabled
+
+
+class ContentExpirySiteAliasHelperTestCase(CMSTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        # Site 1
+        cls.site_1 = Site.objects.get(id=1)
+        # Site 2
+        cls.site_2 = Site(id=2, domain='example-2.com', name='example-2.com')
+        cls.site_2.save()
+
+        cls.category = Category.objects.create(name='site test category')
+
+    def setUp(self):
+        self.superuser = self.get_superuser()
+        Site.objects.clear_cache()
+        # Record that is expired by 1 day
+        from_date = datetime.datetime.now()
+        expire_at = from_date + datetime.timedelta(days=10)
+        language = "en"
+        # Create contents unbound to a site
+        alias_1 = AliasModel.objects.create(
+            category=self.category,
+        )
+        self.alias_content_1 = AliasContent.objects.create(
+            alias=alias_1,
+            name="no site alias 1",
+            language=language,
+        )
+        if is_versioning_enabled():
+            from djangocms_versioning.models import Version
+            self.alias_1_version = Version.objects.create(content=self.alias_content_1, created_by=self.superuser)
+            self.alias_1_version.publish(self.superuser)
+        # Create contents on site 1
+        alias_2 = AliasModel.objects.create(
+            category=self.category,
+            site=self.site_1,
+        )
+        self.alias_content_2 = AliasContent.objects.create(
+            alias=alias_2,
+            name="site 1 alias 1",
+            language=language,
+        )
+        if is_versioning_enabled():
+            from djangocms_versioning.models import Version
+            self.alias_2_version = Version.objects.create(content=self.alias_content_2, created_by=self.superuser)
+            self.alias_2_version.publish(self.superuser)
+        # Create contents on site 2
+        alias_3 = AliasModel.objects.create(
+            category=self.category,
+            site=self.site_2,
+        )
+        self.alias_content_3 = AliasContent.objects.create(
+            alias=alias_3,
+            name="site 1 alias 1",
+            language=language,
+        )
+        if is_versioning_enabled():
+            from djangocms_versioning.models import Version
+            self.alias_3_version = Version.objects.create(content=self.alias_content_3, created_by=self.superuser)
+            self.alias_3_version.publish(self.superuser)
+
+    def tearDown(self):
+        Site.objects.clear_cache()
+
+    def test_helper_alias_exclusion_list_current_site(self):
+        """
+        The list of Alias objects must be filtered by the default / current site
+        """
+        alias_exclusion_list = _get_excluded_alias_site_list(self.site_1)
+
+        self.assertNotIn(self.alias_content_1.pk, alias_exclusion_list)
+        self.assertNotIn(self.alias_content_2.pk, alias_exclusion_list)
+        self.assertIn(self.alias_content_3.pk, alias_exclusion_list)
+
+    @override_settings(SITE_ID=2)
+    def test_helper_alias_exclusion_list_other_site(self):
+        """
+        The list of Alias objects must be filtered by a different site
+        """
+        alias_exclusion_list = _get_excluded_alias_site_list(self.site_2)
+
+        self.assertNotIn(self.alias_content_1.pk, alias_exclusion_list)
+        self.assertIn(self.alias_content_2.pk, alias_exclusion_list)
+        self.assertNotIn(self.alias_content_3.pk, alias_exclusion_list)

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
 
-    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip, https://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning
 
 commands =
     {envpython} --version


### PR DESCRIPTION
Filter Alias objects by the current site. Easiest and most effective way to do this is to exclude any items that are not part of the current site. 