### PR TITLE
Adds pre-commit config and addresses issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - name: Install flake8
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
       - run: python -m pip install isort
@@ -35,4 +35,4 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: isort
-          run: isort -c -rc -df ./
+          run: isort --check-only --diff djangocms_alias

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  -  repo: https://github.com/asottile/pyupgrade
+     rev: v2.31.1
+     hooks:
+       -  id: pyupgrade
+          args: ["--py36-plus"]
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: '1.4.0'
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "2.2"]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-broken-line
+          - flake8-bugbear
+          - flake8-builtins
+          - flake8-coding
+          - flake8-commas
+          - flake8-comprehensions
+          - flake8-eradicate
+          - flake8-quotes
+          - flake8-tidy-imports
+          - pep8-naming
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 ==========
 * feat: Remove Add cta and hide delete dropdown actions from AliasContent admin ChangeList
 * feat: Site field added to plugin
+* feat: Added pre-commit config so that hooks can be installed to ensure coding standards are maintained before issues are picked up during CI and review.
 
 1.0.2 (2022-04-01)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,13 @@ Run::
 to perform the application's database migrations.
 
 
-=====
-Usage
-=====
+To contribute
+=============
+
+The project makes use of pre-commit hooks in git to help maintain coding standards.
+To utilise this during development, need to make sure this is installed.
+
+Run::
+
+    pip install pre-commit
+    pre-commit install

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -13,11 +13,7 @@ from .filters import LanguageFilter
 from .forms import AliasContentForm
 from .models import Alias, AliasContent, Category
 from .urls import urlpatterns
-from .utils import (
-    emit_content_change,
-    emit_content_delete,
-    is_versioning_enabled,
-)
+from .utils import emit_content_change, emit_content_delete, is_versioning_enabled
 
 
 __all__ = [
@@ -27,13 +23,13 @@ __all__ = [
 ]
 
 alias_content_admin_classes = [admin.ModelAdmin]
-alias_content_admin_list_display = ('name', 'get_category',)
+alias_content_admin_list_display = ('name', 'get_category')
 djangocms_versioning_enabled = AliasCMSConfig.djangocms_versioning_enabled
 
 if djangocms_versioning_enabled:
     from djangocms_versioning.admin import ExtendedVersionAdminMixin
     alias_content_admin_classes.insert(0, ExtendedVersionAdminMixin)
-    alias_content_admin_list_display = ('name', 'get_category',)
+    alias_content_admin_list_display = ('name', 'get_category')
 
 
 @admin.register(Category)

--- a/djangocms_alias/cms_plugins.py
+++ b/djangocms_alias/cms_plugins.py
@@ -1,16 +1,10 @@
 from copy import copy
 
-from django.utils.translation import (
-    get_language_from_request,
-    gettext_lazy as _,
-)
+from django.utils.translation import get_language_from_request, gettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase, PluginMenuItem
 from cms.plugin_pool import plugin_pool
-from cms.utils.permissions import (
-    get_model_permission_codename,
-    has_plugin_permission,
-)
+from cms.utils.permissions import get_model_permission_codename, has_plugin_permission
 from cms.utils.plugins import copy_plugins_to_placeholder
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 
@@ -36,7 +30,7 @@ class Alias(CMSPluginBase):
             and instance.is_recursive()
         ):
             return 'djangocms_alias/alias_recursive.html'
-        return 'djangocms_alias/{}/alias.html'.format(instance.template)
+        return f'djangocms_alias/{instance.template}/alias.html'
 
     @classmethod
     def get_extra_plugin_menu_items(cls, request, plugin):

--- a/djangocms_alias/cms_toolbars.py
+++ b/djangocms_alias/cms_toolbars.py
@@ -5,29 +5,15 @@ from django.urls import NoReverseMatch
 from django.utils.encoding import force_str
 from django.utils.translation import gettext, gettext_lazy as _
 
-from cms.cms_toolbars import (
-    ADMIN_MENU_IDENTIFIER,
-    ADMINISTRATION_BREAK,
-    LANGUAGE_MENU_IDENTIFIER,
-    SHORTCUTS_BREAK,
-)
+from cms.cms_toolbars import ADMIN_MENU_IDENTIFIER, ADMINISTRATION_BREAK, LANGUAGE_MENU_IDENTIFIER, SHORTCUTS_BREAK
 from cms.toolbar.items import Break, ButtonList
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from cms.utils.i18n import (
-    force_language,
-    get_language_dict,
-    get_language_tuple,
-)
+from cms.utils.i18n import force_language, get_language_dict, get_language_tuple
 from cms.utils.permissions import get_model_permission_codename
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 
-from .constants import (
-    CATEGORY_LIST_URL_NAME,
-    DELETE_ALIAS_URL_NAME,
-    LIST_ALIASES_URL_NAME,
-    USAGE_ALIAS_URL_NAME,
-)
+from .constants import CATEGORY_LIST_URL_NAME, DELETE_ALIAS_URL_NAME, LIST_ALIASES_URL_NAME, USAGE_ALIAS_URL_NAME
 from .models import Alias, AliasContent
 
 
@@ -223,7 +209,7 @@ class AliasToolbar(CMSToolbar):
 
             if add:
                 add_plugins_menu = language_menu.get_or_create_menu(
-                    '{0}-add'.format(LANGUAGE_MENU_IDENTIFIER),
+                    f'{LANGUAGE_MENU_IDENTIFIER}-add',
                     _('Add Translation'),
                 )
                 add_url = admin_reverse('djangocms_alias_aliascontent_add')
@@ -234,7 +220,7 @@ class AliasToolbar(CMSToolbar):
 
             if remove:
                 remove_plugins_menu = language_menu.get_or_create_menu(
-                    '{0}-del'.format(LANGUAGE_MENU_IDENTIFIER),
+                    f'{LANGUAGE_MENU_IDENTIFIER}-del',
                     _('Delete Translation'),
                 )
                 disabled = len(remove) == 1
@@ -252,7 +238,7 @@ class AliasToolbar(CMSToolbar):
 
             if copy:
                 copy_plugins_menu = language_menu.get_or_create_menu(
-                    '{0}-copy'.format(LANGUAGE_MENU_IDENTIFIER),
+                    f'{LANGUAGE_MENU_IDENTIFIER}-copy',
                     _('Copy all plugins')
                 )
                 title = _('from %s')

--- a/djangocms_alias/forms.py
+++ b/djangocms_alias/forms.py
@@ -1,19 +1,13 @@
 from django import forms
 from django.contrib import admin
-from django.contrib.admin.widgets import (
-    AdminTextInputWidget,
-    RelatedFieldWidgetWrapper,
-)
+from django.contrib.admin.widgets import AdminTextInputWidget, RelatedFieldWidgetWrapper
 from django.contrib.sites.models import Site
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
 from cms.models import CMSPlugin, Placeholder
 from cms.utils import get_current_site
-from cms.utils.permissions import (
-    get_model_permission_codename,
-    has_plugin_permission,
-)
+from cms.utils.permissions import get_model_permission_codename, has_plugin_permission
 from cms.utils.urlutils import admin_reverse
 
 from parler.forms import TranslatableModelForm
@@ -238,7 +232,7 @@ class SetAliasPositionForm(forms.Form):
                     'position': _(
                         'Invalid position in category list, '
                         'available positions are: {}'
-                    ).format([i for i in range(0, alias_count)])
+                    ).format(list(range(0, alias_count)))
                 })
 
         return cleaned_data

--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -133,7 +133,7 @@ class Alias(models.Model):
             if obj_class_name.endswith('Content'):
                 attr_name = obj_class_name.replace('Content', '').lower()
                 attr_related_model = obj._meta.get_field(attr_name).related_model
-                id_attr = getattr(obj, '{}_id'.format(attr_name))
+                id_attr = getattr(obj, f'{attr_name}_id')
                 if id_attr:
                     object_ids[attr_related_model].update([id_attr])
                 else:
@@ -149,21 +149,19 @@ class Alias(models.Model):
 
     def get_name(self, language=None):
         content = self.get_content(language, show_draft_content=True)
-        name = getattr(content, 'name', 'Alias {} (No content)'.format(self.pk))
+        name = getattr(content, 'name', f'Alias {self.pk} (No content)')
         if is_versioning_enabled() and content:
             from djangocms_versioning.constants import DRAFT
             version = content.versions.first()
 
             if version.state == DRAFT:
-                return '{} (Not published)'.format(name)
+                return f'{name} (Not published)'
 
         return name
 
     def get_absolute_url(self, language=None):
         if is_versioning_enabled():
-            from djangocms_versioning.helpers import (
-                version_list_url_for_grouper,
-            )
+            from djangocms_versioning.helpers import version_list_url_for_grouper
 
             return version_list_url_for_grouper(self)
         content = self.get_content(language=language)
@@ -281,7 +279,7 @@ class AliasContent(models.Model):
         verbose_name_plural = _('alias contents')
 
     def __str__(self):
-        return '{} ({})'.format(self.name, self.language)
+        return f'{self.name} ({self.language})'
 
     @cached_property
     def placeholder(self):
@@ -339,7 +337,7 @@ class AliasContent(models.Model):
             plugin_type='Alias',
             language=self.language,
             alias=self.alias,
-            **add_plugin_kwargs
+            **add_plugin_kwargs,
         )
         if replaced_plugin:
             new_plugin.position = replaced_plugin.position

--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -12,10 +12,7 @@ from cms.utils.urlutils import add_url_parameters, admin_reverse
 from classytags.arguments import Argument, MultiValueArgument
 from classytags.core import Tag
 
-from ..constants import (
-    DEFAULT_STATIC_ALIAS_CATEGORY_NAME,
-    USAGE_ALIAS_URL_NAME,
-)
+from ..constants import DEFAULT_STATIC_ALIAS_CATEGORY_NAME, USAGE_ALIAS_URL_NAME
 from ..models import Alias, AliasContent, Category
 from ..utils import is_versioning_enabled
 

--- a/djangocms_alias/views.py
+++ b/djangocms_alias/views.py
@@ -11,10 +11,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.html import conditional_escape
-from django.utils.translation import (
-    get_language_from_request,
-    gettext_lazy as _,
-)
+from django.utils.translation import get_language_from_request, gettext_lazy as _
 from django.views.decorators.http import require_POST
 from django.views.generic import ListView
 
@@ -311,7 +308,7 @@ def alias_usage_view(request, pk):
 
     alias = get_object_or_404(AliasModel.objects.all(), pk=pk)
     opts = Alias.model._meta
-    title = _('Objects using alias: {}'.format(alias))
+    title = _(f'Objects using alias: {alias}')
     context = {
         'has_change_permission': True,
         'opts': opts,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E251,E128,E501,W503
+ignore = C101,C812,E251,E128,E501,Q000,W503
 max-line-length = 119
 exclude =
     *.egg-info,

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ exclude =
     venv
 
 [isort]
-line_length = 79
+line_length = 119
 skip = manage.py, migrations, .tox, .eggs, data, venv
 include_trailing_comma = true
 multi_line_output = 3


### PR DESCRIPTION
This adds the pre-commit config and runs through all the checks so that the pre-commit bot can be added to the repo.

Running this on the entire app causes failures in the test suite, so I've not done that yet.

The failures seem to be that rendered strings end in a new line, and `custom alias content` isn't wrapped in `<b>` tags in the rendered responses.