### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.7.0 (2022-05-31)
+==================
 * feat: Clean out old sass, js and css dist from gulp and package.json
 * feat: Create plugin alias filter to use category and or site
 * fix: Outdated build scripts from Node 5 to Node 16

--- a/djangocms_alias/__init__.py
+++ b/djangocms_alias/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.6.1'
+__version__ = '1.7.0'
 
 default_app_config = 'djangocms_alias.apps.AliasConfig'


### PR DESCRIPTION
Release contains:
* feat: Clean out old sass, js and css dist from gulp and package.json
* feat: Create plugin alias filter to use category and or site
* fix: Outdated build scripts from Node 5 to Node 16