### PR TITLE
fix: AliasContent Admin Category Ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: AliasContent Category admin_order_field incorrect ordering
 
 1.7.0 (2022-05-31)
 ==================

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -114,6 +114,7 @@ class AliasContentAdmin(*alias_content_admin_classes):
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
+        # Force the category set to Lower, to be able to sort the category in ascending/descending order
         queryset = queryset.annotate(alias_category_translations_ordered=Lower("alias__category__translations__name"))
         return queryset
 

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models.functions import Lower
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
@@ -111,12 +112,17 @@ class AliasContentAdmin(*alias_content_admin_classes):
     actions = None
     change_form_template = "admin/djangocms_alias/aliascontent/change_form.html"
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(alias_category_translations_ordered=Lower("alias__category__translations__name"))
+        return queryset
+
     # Add Alias category in the admin manager list and order field
     def get_category(self, obj):
         return obj.alias.category
 
     get_category.short_description = _('category')
-    get_category.admin_order_field = "alias__category"
+    get_category.admin_order_field = "alias_category_translations_ordered"
 
     def has_add_permission(self, request, obj=None):
         # FIXME: It is not currently possible to add an alias from the django admin changelist issue #97

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -3,6 +3,7 @@ django-app-helper
 flake8
 isort
 pyflakes>=2.1.1
+bs4
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -1,9 +1,9 @@
+bs4
 coverage
 django-app-helper
 flake8
 isort
 pyflakes>=2.1.1
-bs4
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,7 +6,7 @@ from django.utils.timezone import localtime
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
 
-from bs4 import BeautifulSoup as bs
+from bs4 import BeautifulSoup
 
 from djangocms_alias.constants import USAGE_ALIAS_URL_NAME
 from djangocms_alias.models import Alias as AliasModel, AliasContent, Category
@@ -276,7 +276,6 @@ class AliasContentManagerTestCase(CMSTestCase):
         last_category, last_alias, last_alias_content = self._create_alias_and_categories(
             "Z Order Test Case Upper"
         )
-
         # Create the versions for each alias content
         from djangocms_versioning.models import Version
         Version.objects.create(content=first_alias_content, created_by=self.superuser)
@@ -291,7 +290,7 @@ class AliasContentManagerTestCase(CMSTestCase):
             base_url += "?o=1"
             # en is the default language configured for the site
             response = self.client.get(base_url)
-        soup = bs(response.content, "html.parser")
+        soup = BeautifulSoup(response.content, "html.parser")
         results = soup.find_all("td", class_="field-get_category")
 
         # Test results are in ascending alphabetical order
@@ -307,7 +306,7 @@ class AliasContentManagerTestCase(CMSTestCase):
             base_url += "?o=-1"
             # en is the default language configured for the site
             response = self.client.get(base_url)
-        soup = bs(response.content, "html.parser")
+        soup = BeautifulSoup(response.content, "html.parser")
         results = soup.find_all("td", class_="field-get_category")
 
         # Test results are in descending alphabetical order

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -258,7 +258,7 @@ class AliasContentManagerTestCase(CMSTestCase):
 
     def test_category_field_ordering(self):
         """
-        Category can be ordered by name, both in ascending and descending order
+        Related category can be ordered by name, both in ascending and descending order
         """
         # Create a number of categories, aliases, and alias content to order
         first_category, first_alias, first_alias_content = self._create_alias_and_categories("First Order Test Case")
@@ -287,7 +287,32 @@ class AliasContentManagerTestCase(CMSTestCase):
 
         with self.login_user_context(self.superuser):
             base_url = self.get_admin_url(AliasContent, "changelist")
+            # o=1 indicates ascending alphabetical order on list_displays second entry
             base_url += "?o=1"
             # en is the default language configured for the site
             response = self.client.get(base_url)
         soup = bs(response.content, "html.parser")
+        results = soup.find_all("td", class_="field-get_category")
+
+        # Test results are in ascending alphabetical order
+        self.assertEqual(results[0].text, first_alias_content.name)
+        self.assertEqual(results[1].text, first_alias_content_lower.name)
+        self.assertEqual(results[2].text, middle_alias_content.name)
+        self.assertEqual(results[3].text, last_alias_content_lower.name)
+        self.assertEqual(results[4].text, last_alias_content.name)
+
+        with self.login_user_context(self.superuser):
+            base_url = self.get_admin_url(AliasContent, "changelist")
+            # o=-1 indicates descending alphabetical order on list_displays second entry
+            base_url += "?o=-1"
+            # en is the default language configured for the site
+            response = self.client.get(base_url)
+        soup = bs(response.content, "html.parser")
+        results = soup.find_all("td", class_="field-get_category")
+
+        # Test results are in descending alphabetical order
+        self.assertEqual(results[4].text, first_alias_content.name)
+        self.assertEqual(results[3].text, first_alias_content_lower.name)
+        self.assertEqual(results[2].text, middle_alias_content.name)
+        self.assertEqual(results[1].text, last_alias_content_lower.name)
+        self.assertEqual(results[0].text, last_alias_content.name)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -256,9 +256,10 @@ class AliasContentManagerTestCase(CMSTestCase):
         )
         return category, alias, alias_content
 
-    def test_category_field_ordering(self):
+    @skipUnless(is_versioning_enabled(), 'Test only relevant for versioning')
+    def test_category_field_ordering_versioned(self):
         """
-        Related category can be ordered by name, both in ascending and descending order
+        Related category can be ordered by name, both in ascending and descending order, with versioning
         """
         # Create a number of categories, aliases, and alias content to order
         first_category, first_alias, first_alias_content = self._create_alias_and_categories("First Order Test Case")
@@ -283,6 +284,60 @@ class AliasContentManagerTestCase(CMSTestCase):
         Version.objects.create(content=middle_alias_content, created_by=self.superuser)
         Version.objects.create(content=last_alias_content_lower, created_by=self.superuser)
         Version.objects.create(content=last_alias_content, created_by=self.superuser)
+
+        with self.login_user_context(self.superuser):
+            base_url = self.get_admin_url(AliasContent, "changelist")
+            # o=1 indicates ascending alphabetical order on list_displays second entry
+            base_url += "?o=1"
+            # en is the default language configured for the site
+            response = self.client.get(base_url)
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find_all("td", class_="field-get_category")
+
+        # Test results are in ascending alphabetical order
+        self.assertEqual(results[0].text, first_alias_content.name)
+        self.assertEqual(results[1].text, first_alias_content_lower.name)
+        self.assertEqual(results[2].text, middle_alias_content.name)
+        self.assertEqual(results[3].text, last_alias_content_lower.name)
+        self.assertEqual(results[4].text, last_alias_content.name)
+
+        with self.login_user_context(self.superuser):
+            base_url = self.get_admin_url(AliasContent, "changelist")
+            # o=-1 indicates descending alphabetical order on list_displays second entry
+            base_url += "?o=-1"
+            # en is the default language configured for the site
+            response = self.client.get(base_url)
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find_all("td", class_="field-get_category")
+
+        # Test results are in descending alphabetical order
+        self.assertEqual(results[4].text, first_alias_content.name)
+        self.assertEqual(results[3].text, first_alias_content_lower.name)
+        self.assertEqual(results[2].text, middle_alias_content.name)
+        self.assertEqual(results[1].text, last_alias_content_lower.name)
+        self.assertEqual(results[0].text, last_alias_content.name)
+
+    @skipUnless(not is_versioning_enabled(), 'Test only relevant for versioning')
+    def test_category_field_ordering_unversioned(self):
+        """
+        Related category can be ordered by name, both in ascending and descending order, without versioning
+        """
+        # Create a number of categories, aliases, and alias content to order
+        first_category, first_alias, first_alias_content = self._create_alias_and_categories("First Order Test Case")
+        # Previously lowercase and upper case would be sorted separately, test they are ordered together
+        first_category_lower, first_alias_lower, first_alias_content_lower = self._create_alias_and_categories(
+            "first order test case lower"
+        )
+        middle_category, middle_alias, middle_alias_content = self._create_alias_and_categories(
+            "Middle Order Test Case"
+        )
+        # Previously lowercase and upper case would be sorted separately, test they are ordered together
+        last_category_lower, last_alias_lower, last_alias_content_lower = self._create_alias_and_categories(
+            "z order test case lower"
+        )
+        last_category, last_alias, last_alias_content = self._create_alias_and_categories(
+            "Z Order Test Case Upper"
+        )
 
         with self.login_user_context(self.superuser):
             base_url = self.get_admin_url(AliasContent, "changelist")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,6 +6,8 @@ from django.utils.timezone import localtime
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
 
+from bs4 import BeautifulSoup as bs
+
 from djangocms_alias.constants import USAGE_ALIAS_URL_NAME
 from djangocms_alias.models import Alias as AliasModel, AliasContent, Category
 from djangocms_alias.utils import is_versioning_enabled
@@ -241,3 +243,51 @@ class AliasContentManagerTestCase(CMSTestCase):
             add_aliascontent_url,
             response_content_decoded,
         )
+
+    def _create_alias_and_categories(self, category_name, alias_content_name=None):
+        if not alias_content_name:
+            alias_content_name = category_name
+        category = Category.objects.create(name=category_name)
+        alias = AliasModel.objects.create(category=category, position=0)
+        alias_content = AliasContent.objects.create(
+            alias=alias,
+            name=alias_content_name,
+            language="en"
+        )
+        return category, alias, alias_content
+
+    def test_category_field_ordering(self):
+        """
+        Category can be ordered by name, both in ascending and descending order
+        """
+        # Create a number of categories, aliases, and alias content to order
+        first_category, first_alias, first_alias_content = self._create_alias_and_categories("First Order Test Case")
+        # Previously lowercase and upper case would be sorted separately, test they are ordered together
+        first_category_lower, first_alias_lower, first_alias_content_lower = self._create_alias_and_categories(
+            "first order test case lower"
+        )
+        middle_category, middle_alias, middle_alias_content = self._create_alias_and_categories(
+            "Middle Order Test Case"
+        )
+        # Previously lowercase and upper case would be sorted separately, test they are ordered together
+        last_category_lower, last_alias_lower, last_alias_content_lower = self._create_alias_and_categories(
+            "z order test case lower"
+        )
+        last_category, last_alias, last_alias_content = self._create_alias_and_categories(
+            "Z Order Test Case Upper"
+        )
+
+        # Create the versions for each alias content
+        from djangocms_versioning.models import Version
+        Version.objects.create(content=first_alias_content, created_by=self.superuser)
+        Version.objects.create(content=first_alias_content_lower, created_by=self.superuser)
+        Version.objects.create(content=middle_alias_content, created_by=self.superuser)
+        Version.objects.create(content=last_alias_content_lower, created_by=self.superuser)
+        Version.objects.create(content=last_alias_content, created_by=self.superuser)
+
+        with self.login_user_context(self.superuser):
+            base_url = self.get_admin_url(AliasContent, "changelist")
+            base_url += "?o=1"
+            # en is the default language configured for the site
+            response = self.client.get(base_url)
+        soup = bs(response.content, "html.parser")


### PR DESCRIPTION
Previously, admin field ordering on Category would order all categories beginning with capital letters and lowercase letters seperately. Now they are ordered appropriately, regardless of case.