### PR TITLE
fix: Avoid language = None when auto creating static aliases

### DIFF
--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -90,7 +90,7 @@ class StaticAlias(Tag):
             # Try getting language from the toolbar first (end and view endpoints)
             language = getattr(request.toolbar.get_object(), "language", None)
             if language not in get_language_list(current_site):
-                language = None
+                language = get_language_from_request(request)
         else:
             language = get_language_from_request(request)
         # Try and find an Alias to render


### PR DESCRIPTION
Fixes #168/#162, a bug introduced in #165.

Instead of setting `language = None` if the toolbar language is not part of the language list, now the language for the alias is taken from the request. `cms.utils.get_language_from_request` falls back to the site's default language if none can be retrieved from the request. 