### PR TITLE
fix: Simplify versioning interaction for better disentanglement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-Unreleased
-==========
+2.0.0rc1
+========
 * Django 4.0 and 4.1 support added
 * Django 2.2 support removed
 * Python 3.7 support removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 2.0.0rc1
 ========
-* Django 4.0 and 4.1 support added
+* Django 4.0, 4.1, and 4.2 support added
 * Django 2.2 support removed
 * Python 3.7 support removed
 * Changed test setup to run tox from github actions for consistency in testing

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1400,12 +1400,8 @@ class AliasViewsUsingVersioningTestCase(BaseAliasPluginTestCase):
         When visiting a published page with a draft alias the alias
         is not visible
         """
-        from djangocms_versioning.helpers import remove_published_where
-
         unpublished_alias = self._create_alias(published=False)
-        content = remove_published_where(
-            unpublished_alias.contents.filter(language=self.language)
-        ).first()
+        content = unpublished_alias.contents(manager="admin_manager").filter(language=self.language).first()
         alias_placeholder = content.placeholder
 
         body = 'unpublished alias'


### PR DESCRIPTION
This PR removes an unnecessary import of `djangocms_versioning.helpers.remove_published_where`. By importing this helper function, alias implicitly makes a very precise assumption on how versioning works which it should not.

This helper function is replaced by the `admin_manager` of the content model.

This disentanglement is necessary to allow for alternative versioning packages to work with alias.