### PR TITLE
Allow using variable as identifier in static_alias template tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Unreleased
+==========
+* fix: Allow using a variable as the identifier in static_alias template tag
+
 2.0.0rc1
 ========
 * Django 4.0, 4.1, and 4.2 support added

--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -69,7 +69,7 @@ class StaticAlias(Tag):
     """
     name = 'static_alias'
     options = PlaceholderOptions(
-        Argument('static_code', resolve=False),
+        Argument('static_code', resolve=True),
         MultiValueArgument('extra_bits', required=False, resolve=False),
         blocks=[
             ('endstatic_alias', 'nodelist'),

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -340,3 +340,22 @@ class AliasTemplateTagAliasPlaceholderTestCase(BaseAliasPluginTestCase):
 
         self.assertIsNotNone(alias.get_content("en", show_draft_content=True))
         self.assertIsNotNone(alias.get_content("de", show_draft_content=True))
+
+    def test_alias_rendered_when_identifier_is_variable(self):
+        alias_template = """{% load djangocms_alias_tags %}{% static_alias foo_variable %}"""  # noqa: E501
+
+        alias = self._create_alias(static_code="some_unique_id")
+        add_plugin(
+            alias.get_placeholder(self.language),
+            'TextPlugin',
+            language=self.language,
+            body='Content Alias 1234',
+        )
+
+        output = self.render_template_obj(
+            alias_template,
+            {'foo_variable': "some_unique_id"},
+            self.get_request('/'),
+        )
+
+        self.assertEqual(output, "Content Alias 1234")


### PR DESCRIPTION
Unless there's a good reason not to, I'd like to suggest to allow variables as identifiers for the `static_alias` template tag.

This is possible with `static_placeholder` and because `static_alias` is the recommended replacement, it would make sense to support variables here.