### PR TITLE
fix: New migrations in cms cause migration failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Migration dependency on latest django-cms migration.
 * fix: Allow using a variable as the identifier in static_alias template tag
 
 2.0.0rc1

--- a/djangocms_alias/migrations/0003_auto_20230725_1547.py
+++ b/djangocms_alias/migrations/0003_auto_20230725_1547.py
@@ -6,7 +6,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '__latest__'),
+        ('cms', '__first__'),
         ('djangocms_alias', '0002_auto_20200723_1424'),
     ]
 


### PR DESCRIPTION
Depending on the latest django-cms migration means applying alias migrations and then having django-cms include new migrations leads to an error that alias was applied before the latest django-cms migration.