### PR TITLE
fix: Enable caching for `static_alias` template tag

### DIFF
--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -176,6 +176,7 @@ class StaticAlias(Tag):
                 placeholder=placeholder,
                 context=context,
                 nodelist=nodelist,
+                use_cache=True,
             )
             return content
         return ''


### PR DESCRIPTION
adding use_cache to static_alias to allow caching

based on Slack discussion

![obrazek](https://github.com/django-cms/djangocms-alias/assets/2572537/cd512835-babe-4872-bc0a-e1d20707563b)
