### PR TITLE
fix: `static_alias` unnecessarily creates new content objects when used with versioning

### DIFF
--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -109,7 +109,7 @@ class StaticAlias(Tag):
             if is_versioning_enabled() and not request.user.is_authenticated:
                 return None
 
-            # Parlers get_or_create doesn't work well with translations, so we must perform our own get or create
+            # Parler's get_or_create doesn't work well with translations, so we must perform our own get or create
             default_category = Category.objects.filter(translations__name=DEFAULT_STATIC_ALIAS_CATEGORY_NAME).first()
             if not default_category:
                 default_category = Category.objects.create(name=DEFAULT_STATIC_ALIAS_CATEGORY_NAME)
@@ -124,7 +124,7 @@ class StaticAlias(Tag):
 
             alias = Alias.objects.create(category=default_category, **alias_creation_kwargs)
 
-        if not AliasContent._default_manager.filter(alias=alias, language=language).exists():
+        if not AliasContent._base_manager.filter(alias=alias, language=language).exists():
             # Create a first content object if none exists in the given language.
             # If versioning is enabled we can only create the records with a logged-in user / staff member
             if is_versioning_enabled() and not request.user.is_authenticated:

--- a/tests/requirements/py311-djmain-cms41-default.txt
+++ b/tests/requirements/py311-djmain-cms41-default.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 beautifulsoup4==4.12.2
     # via bs4
@@ -31,7 +31,7 @@ django-classy-tags==4.0.0
     #   -r requirements.in
     #   django-cms
     #   django-sekizai
-django-cms==4.1.0rc3
+git+https://github.com/django-cms/django-cms@develop-4#egg=django-cms
     # via
     #   -r requirements.in
     #   djangocms-versioning

--- a/tests/requirements/py311-djmain-cms41-versioning.txt
+++ b/tests/requirements/py311-djmain-cms41-versioning.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 beautifulsoup4==4.12.2
     # via bs4
@@ -31,7 +31,7 @@ django-classy-tags==4.0.0
     #   -r requirements.in
     #   django-cms
     #   django-sekizai
-django-cms==4.1.0rc3
+git+https://github.com/django-cms/django-cms@develop-4#egg=django-cms
     # via
     #   -r requirements.in
     #   djangocms-versioning

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -334,12 +334,15 @@ class AliasTemplateTagAliasPlaceholderTestCase(BaseAliasPluginTestCase):
 
         with self.login_user_context(self.superuser):
             self.client.get(page_edit_url("en"))  # supposed to create the alias and alias content for en
+            self.client.get(page_edit_url("en"))  # supposed to create no additional object
             self.client.get(page_edit_url("de"))  # supposed to create the alias content for de
 
         alias = AliasModel.objects.get(static_code="template_example_global_alias_code")
 
         self.assertIsNotNone(alias.get_content("en", show_draft_content=True))
         self.assertIsNotNone(alias.get_content("de", show_draft_content=True))
+        # Ensure that exactly two content objects have been created
+        self.assertEqual(alias.contents(manager="admin_manager").count(), 2)
 
     def test_alias_rendered_when_identifier_is_variable(self):
         alias_template = """{% load djangocms_alias_tags %}{% static_alias foo_variable %}"""  # noqa: E501


### PR DESCRIPTION
This PR fixes a regression introduced in #165 which leads to the creation of a new `AliasContent` object for a language

* each time the page with the template tag is viewed
* if no published version of the alias content is available

The regression is triggered by using `_default_manager` once where `_base_manager` should have been used.

#165 introduced a test but missed the regression. This PR adds a regression test. 