### PR TITLE
fix djangocms-versioning draft deletion bug (#214)

### DIFF
--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -193,7 +193,9 @@ class AliasContentAdmin(admin.ModelAdmin):
 
     def delete_model(self, request: HttpRequest, obj: AliasContent):
         if obj.alias._default_manager.filter(language=obj.language).count() == 1:
-            message = _("Alias content for language {} deleted. A new empty alias content will be created if needed.").format(obj.language)
+            message = _(
+                "Alias content for language {} deleted. A new empty alias content will be created if needed."
+            ).format(obj.language)
             self.message_user(request, message, level=messages.WARNING)
 
         return super().delete_model(

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -2,7 +2,7 @@ from cms.admin.utils import GrouperModelAdmin
 from cms.utils.permissions import get_model_permission_codename
 from cms.utils.urlutils import admin_reverse
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.http import (
     Http404,
     HttpRequest,
@@ -190,3 +190,13 @@ class AliasContentAdmin(admin.ModelAdmin):
         """Hides admin class in admin site overview"""
 
         return False
+
+    def delete_model(self, request: HttpRequest, obj: AliasContent):
+        if obj.alias._default_manager.filter(language=obj.language).count() == 1:
+            message = _("Alias content for language {} deleted. A new empty alias content will be created if needed.").format(obj.language)
+            self.message_user(request, message, level=messages.WARNING)
+
+        return super().delete_model(
+            request=request,
+            obj=obj,
+        )

--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -292,11 +292,6 @@ class AliasContent(models.Model):
         return "djangocms_alias/alias_content.html"
 
     @transaction.atomic
-    def delete(self, *args, **kwargs):
-        super().delete(*args, **kwargs)
-        self.alias.cms_plugins.filter(language=self.language).delete()
-
-    @transaction.atomic
     def populate(self, replaced_placeholder=None, replaced_plugin=None, plugins=None):
         if not replaced_placeholder and not replaced_plugin:
             copy_plugins_to_placeholder(


### PR DESCRIPTION
Previously, `djangocms_alias.models.AliasContent.delete` deleted all plugins related to `AliasContent.alias`, with the same language. Drafts and previously published versions included.
This meant that the deletion of a draft resulted in plugins disappearing from published pages.

This patch removes the mechanism entirely and instead adds a warning, notifying the user that the last version or translation of a language got deleted.