### PR TITLE
chore: removed final newline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ quote_type = single
 [*.{scss,js,html}]
 max_line_length = 120
 indent_style = space
+insert_final_newline = false
 quote_type = double
 
 [*.js]


### PR DESCRIPTION
Updated the editor configurations under [Mark's suggestion](https://github.com/django-cms/djangocms-alias/pull/217): 

```
[*.{scss,js,html}]
max_line_length = 120
indent_style = space
insert_final_newline = false
quote_type = double
```

