### PR TITLE
Fix: removed 'submit-row' from detach_alias.html 

### DIFF
--- a/djangocms_alias/templates/djangocms_alias/detach_alias.html
+++ b/djangocms_alias/templates/djangocms_alias/detach_alias.html
@@ -12,7 +12,7 @@
 
 <form method="post">{% csrf_token %}
   <input type="hidden" name="post" value="yes" />
-  <div class="submit-row">
+  <div>
     <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
     <input type="submit" value="{% trans "Yes, I'm sure" %}" />
   </div>

--- a/djangocms_alias/templates/djangocms_alias/detach_alias.html
+++ b/djangocms_alias/templates/djangocms_alias/detach_alias.html
@@ -12,9 +12,9 @@
 
 <form method="post">{% csrf_token %}
   <input type="hidden" name="post" value="yes" />
-  <div>
+  <div class="submit-row">
     <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
-    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+    <input type="submit" class="deletelink" value="{% trans "Yes, I'm sure" %}" />
   </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Description

The css class `submit-row` causes a weird behavior while extending the `delete_confirmation.html` template – resulting in 404 every time a Alias is detached in the structure view. 

***

* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
