### PR TITLE
fix: wizard creation error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 * fix: `get_absolute_url` method not found while creating new alias and category from wizard button.
+* feat: Added search capability in AliasContent admin (migrate the 4.0.x feature from PR #236)
 
 
 2.0.1 (2024-03-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+==========
+* fix: `get_absolute_url` method not found while creating new alias and category from wizard button.
+
+
 2.0.1 (2024-03-27)
 ==================
 

--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -80,6 +80,7 @@ class AliasAdmin(*alias_admin_classes):
     )
     fields = ("content__name", "category", "site", "content__language")
     readonly_fields = ("static_code",)
+    search_fields = ["content__name"]
     form = AliasGrouperAdminForm
     extra_grouping_fields = ("language",)
     EMPTY_CONTENT_VALUE = mark_safe(_("<i>Missing language</i>"))

--- a/djangocms_alias/cms_wizards.py
+++ b/djangocms_alias/cms_wizards.py
@@ -12,6 +12,9 @@ from .models import Category
 class CreateAliasWizard(Wizard):
     def user_has_add_permission(self, user, **kwargs):
         return Alias.can_create_alias(user)
+    
+    def get_success_url(self, obj, **kwargs):
+        return obj.get_admin_change_url()
 
 
 class CreateAliasCategoryWizard(Wizard):
@@ -19,6 +22,9 @@ class CreateAliasCategoryWizard(Wizard):
         return user.has_perm(
             get_model_permission_codename(Category, "add"),
         )
+    
+    def get_success_url(self, obj, **kwargs):
+        return obj.get_admin_change_url()
 
 
 create_alias_wizard = CreateAliasWizard(

--- a/djangocms_alias/cms_wizards.py
+++ b/djangocms_alias/cms_wizards.py
@@ -12,7 +12,7 @@ from .models import Category
 class CreateAliasWizard(Wizard):
     def user_has_add_permission(self, user, **kwargs):
         return Alias.can_create_alias(user)
-    
+
     def get_success_url(self, obj, **kwargs):
         return obj.get_admin_change_url()
 
@@ -22,7 +22,7 @@ class CreateAliasCategoryWizard(Wizard):
         return user.has_perm(
             get_model_permission_codename(Category, "add"),
         )
-    
+
     def get_success_url(self, obj, **kwargs):
         return obj.get_admin_change_url()
 

--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -17,7 +17,7 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from parler.models import TranslatableModel, TranslatedFields
 
-from .constants import CHANGE_CATEGORY_URL_NAME
+from .constants import CHANGE_ALIAS_URL_NAME, CHANGE_CATEGORY_URL_NAME
 from .utils import is_versioning_enabled
 
 __all__ = [
@@ -122,6 +122,9 @@ class Alias(models.Model):
     @cached_property
     def is_in_use(self):
         return self.cms_plugins.exists()
+
+    def get_admin_change_url(self):
+        return admin_reverse(CHANGE_ALIAS_URL_NAME, args=[self.pk])
 
     @cached_property
     def objects_using(self):

--- a/tests/requirements/py311-djmain-cms41-default.txt
+++ b/tests/requirements/py311-djmain-cms41-default.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.7.2
+asgiref==3.8.1
     # via django
 beautifulsoup4==4.12.2
     # via bs4

--- a/tests/requirements/py311-djmain-cms41-versioning.txt
+++ b/tests/requirements/py311-djmain-cms41-versioning.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.7.2
+asgiref==3.8.1
     # via django
 beautifulsoup4==4.12.2
     # via bs4

--- a/tests/requirements/py311-djmain-cms4dev-default.txt
+++ b/tests/requirements/py311-djmain-cms4dev-default.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.7.2
+asgiref==3.8.1
     # via django
 beautifulsoup4==4.12.2
     # via bs4

--- a/tests/requirements/py311-djmain-cms4dev-versioning.txt
+++ b/tests/requirements/py311-djmain-cms4dev-versioning.txt
@@ -4,7 +4,7 @@
 #
 #    requirements/compile.py
 #
-asgiref==3.7.2
+asgiref==3.8.1
     # via django
 beautifulsoup4==4.12.2
     # via bs4

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -554,9 +554,9 @@ class AliasesManagerTestCase(BaseAliasPluginTestCase):
         response = self.client.get(index_url)
 
         unexpected_content = (
-            '<th scope="row"><a href="/en/admin/djangocms_alias/aliascontent/">' "Alias contents</a></th>"
+            '<a href="/en/admin/djangocms_alias/aliascontent/">' "Alias contents</a>"
         )
-        expected_content = '<th scope="row"><a href="/en/admin/djangocms_alias/alias/">Aliases</a></th>'
+        expected_content = '<a href="/en/admin/djangocms_alias/alias/">Aliases</a>'
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, expected_content)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -553,9 +553,7 @@ class AliasesManagerTestCase(BaseAliasPluginTestCase):
 
         response = self.client.get(index_url)
 
-        unexpected_content = (
-            '<a href="/en/admin/djangocms_alias/aliascontent/">' "Alias contents</a>"
-        )
+        unexpected_content = '<a href="/en/admin/djangocms_alias/aliascontent/">' "Alias contents</a>"
         expected_content = '<a href="/en/admin/djangocms_alias/alias/">Aliases</a>'
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Description

Fix #244 mentioned `get_absolute_url` missing error while creating new alias and alias category from wizard button
I also manually cherry-pick the **search** features that exists in `branch 4.0.1.x` but not in `master` branch.

Thus, we don't need to care about branch 4.0.1.x now.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #244 
* #236 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
