### PR TITLE
Fix: skip objects using placeholders without source 

### DIFF
--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -133,6 +133,11 @@ class Alias(models.Model):
         plugins = self.cms_plugins.select_related("placeholder").prefetch_related("placeholder__source")
         for plugin in plugins:
             obj = plugin.placeholder.source
+
+            # Skip plugins that have no placeholder source e.g clipboard
+            if obj is None:
+                continue
+
             obj_class_name = obj.__class__.__name__
             if obj_class_name.endswith("Content"):
                 attr_name = obj_class_name.replace("Content", "").lower()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1580,3 +1580,24 @@ class AliasViewsUsingVersioningTestCase(BaseAliasPluginTestCase):
         self.assertNotContains(list_response, alias_content_de.name)
         self.assertNotContains(detail_response, en_plugin.body)
         self.assertNotContains(list_response, alias.name)
+
+    def test_usage_view_if_alias_is_saved_to_clipboard(self):
+        """
+        The usage view should ignore the clipboard entry
+        """
+
+        alias = self._create_alias()
+        placeholder = Placeholder.objects.create(slot="clipboard")
+        add_plugin(placeholder, "Alias", language="en", alias=alias)
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(
+                admin_reverse(
+                    USAGE_ALIAS_URL_NAME,
+                    args=[alias.pk],
+                ),
+            )
+
+            self.assertEqual(response.status_code, 200)
+            # Check that the alias is displayed in the response content
+            self.assertContains(response, alias.name)


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

For example if an AliasPlugin is saved to the Clipboard it will cause an `AttributeError` in the `alias_usage_view` since the placeholder does not have a valid source.  

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
