### PR TITLE
ci: Include hidden file in artifact build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ matrix.python-version }}
+          include-hidden-files: true
           path: '${{ github.workspace }}/.coverage.*'
 
   coverage:


### PR DESCRIPTION
## Description

Quick test to see if adding `include-hidden-file` works

* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

CI:
- Upload hidden coverage files as artifacts.