### PR TITLE
build: Add a description for pypi

### DIFF
--- a/djangocms_alias/__init__.py
+++ b/djangocms_alias/__init__.py
@@ -1,1 +1,6 @@
+"""
+An alias is a collection of plugins that is managed centrally.
+A reference can be added to any placeholder using the Alias plugin.
+"""
+
 __version__ = "2.0.2"


### PR DESCRIPTION
Currently the pypi description is "None". This adds a description.

## Summary by Sourcery

Documentation:
- Adds a package description to the module's docstring.