### PR TITLE
Create Alias plugin form is missing autocompletion

### DIFF
--- a/djangocms_alias/static/djangocms_alias/js/create.js
+++ b/djangocms_alias/static/djangocms_alias/js/create.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 $(function() {
     var itemsPerPage = 30;
     var siteField = $('#id_site');


### PR DESCRIPTION
## Description

When creating a new Alias plugin, the form only shows bare text inputs, without the autocomplete fields. As the relevant script contains an import statement, which isn't allowed when using a script tag without `type=module`. Since jQuery is available globally, the import is not necessary.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

Enable autocompletion on the Alias plugin creation form by removing the ES module import and using the globally available jQuery AutocompleteSelect.

Bug Fixes:
- Restore missing autocomplete fields in the Alias plugin form.

Enhancements:
- Initialize AutocompleteSelect via global jQuery instead of relying on an import.

Tests:
- Add or update tests to cover the Alias plugin form autocompletion logic.