### PR TITLE
fix: Use cms_config to register wizards robustly

### DIFF
--- a/djangocms_alias/cms_config.py
+++ b/djangocms_alias/cms_config.py
@@ -6,7 +6,6 @@ from .cms_wizards import (
     create_alias_category_wizard,
     create_alias_wizard,
 )
-
 from .models import AliasContent, AliasPlugin, copy_alias_content
 from .rendering import render_alias_content
 

--- a/djangocms_alias/cms_config.py
+++ b/djangocms_alias/cms_config.py
@@ -2,6 +2,11 @@ from cms.app_base import CMSAppConfig
 from django.apps import apps
 from django.conf import settings
 
+from .cms_wizards import (
+    create_alias_category_wizard,
+    create_alias_wizard,
+)
+
 from .models import AliasContent, AliasPlugin, copy_alias_content
 from .rendering import render_alias_content
 
@@ -18,6 +23,7 @@ class AliasCMSConfig(CMSAppConfig):
     cms_enabled = True
     cms_toolbar_enabled_models = [(AliasContent, render_alias_content)]
     moderated_models = [AliasContent]
+    cms_wizards = [create_alias_wizard, create_alias_category_wizard]
 
     djangocms_moderation_enabled = getattr(settings, "MODERATING_ALIAS_MODELS_ENABLED", True)
     djangocms_versioning_enabled = (

--- a/djangocms_alias/cms_wizards.py
+++ b/djangocms_alias/cms_wizards.py
@@ -41,6 +41,3 @@ create_alias_category_wizard = CreateAliasCategoryWizard(
     model=Category,
     description=_("Create a new alias category."),
 )
-
-wizard_pool.register(create_alias_wizard)
-wizard_pool.register(create_alias_category_wizard)

--- a/djangocms_alias/cms_wizards.py
+++ b/djangocms_alias/cms_wizards.py
@@ -1,6 +1,5 @@
 from cms.utils.permissions import get_model_permission_codename
 from cms.wizards.wizard_base import Wizard
-from cms.wizards.wizard_pool import wizard_pool
 from django.utils.translation import gettext_lazy as _
 
 from .cms_plugins import Alias


### PR DESCRIPTION
## Description

This fix removes the deprecated wizard registration which causes problems with Django 5.1+.
As recommended, it uses the `cms_config` to register the wizards.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

Switch wizard registration to CMSAppConfig cms_wizards and remove deprecated wizard_pool.register calls

Bug Fixes:
- Restore alias wizard registration compatibility with Django 5.1+ by removing deprecated registration method

Enhancements:
- Declare create_alias_wizard and create_alias_category_wizard in AliasCMSConfig.cms_wizards instead of using wizard_pool.register