### PR TITLE
docs: specify how to customize preview & edit alias template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ You can override this default behaviour by supplying your own template at::
 
     templates/djangocms_alias/base.html
 
-The provided template will then be used when rendering aliases in edit and preview 
+The provided template will then be used when rendering aliases in edit and preview
 modes. Also, it does not need to extend your main ``base.html`` template.
 
 However, be sure that the required CMS tags and assets are included, for example::


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
- This PR adds a section to the README describing how to customize preview & edit alias templates. 
- This allows developers to use a minimal layout instead of the default CMS template.
- Earlier opened in Django-CMS [pull #853](https://github.com/django-cms/django-cms/pull/853)
- Fixes fixes https://github.com/django-cms/djangocms-alias/issues/255 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->
 
* https://docs.django-cms.org/en/latest/how_to/04-templates.html

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

Documentation:
- Add README guidance for overriding preview and edit alias templates to support custom or minimal layouts.