### PR TITLE
fix: djangocms-alias did not recognize versioning installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 
 ## What's Changed
 
+3.1.1 (2026-05-20)
+==================
+
+* fix: djangocms-versioning was not recognized for django CMS 5.0 or less
+
 3.1.0 (2026-05-14)
 ==================
 

--- a/djangocms_alias/__init__.py
+++ b/djangocms_alias/__init__.py
@@ -3,4 +3,4 @@ An alias is a collection of plugins that is managed centrally.
 A reference can be added to any placeholder using the Alias plugin.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -5,9 +5,17 @@ from django.apps import apps
 
 @cache
 def get_versionable_item(cms_config) -> type | None:
+    VersionableItem = None
     if hasattr(cms_config, "get_contract"):
         return cms_config.get_contract("djangocms_versioning")
-    return None
+    elif apps.in_installed("djangocms_versioning"):
+        # Pre django CMS 5.1
+        try:
+            from djangocms_versioning.datastructure import VersionableItem
+            raise ImportError("djangocms_versioning is not installed")
+        except ImportError:
+            return None
+    return VersionableItem
 
 
 def is_versioning_enabled() -> bool:

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -12,8 +12,6 @@ def get_versionable_item(cms_config) -> type | None:
         # Pre django CMS 5.1
         try:
             from djangocms_versioning.datastructure import VersionableItem
-
-            raise ImportError("djangocms_versioning is not installed")
         except ImportError:
             return None
     return VersionableItem

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -8,7 +8,7 @@ def get_versionable_item(cms_config) -> type | None:
     VersionableItem = None
     if hasattr(cms_config, "get_contract"):
         return cms_config.get_contract("djangocms_versioning")
-    elif apps.in_installed("djangocms_versioning"):
+    elif apps.is_installed("djangocms_versioning"):
         # Pre django CMS 5.1
         try:
             from djangocms_versioning.datastructure import VersionableItem

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -5,16 +5,17 @@ from django.apps import apps
 
 @cache
 def get_versionable_item(cms_config) -> type | None:
-    VersionableItem = None
     if hasattr(cms_config, "get_contract"):
         return cms_config.get_contract("djangocms_versioning")
     elif apps.is_installed("djangocms_versioning"):
         # Pre django CMS 5.1
         try:
-            from djangocms_versioning.datastructure import VersionableItem
+            from djangocms_versioning.datastructures import VersionableItem
+
+            return VersionableItem
         except ImportError:
             return None
-    return VersionableItem
+    return None
 
 
 def is_versioning_enabled() -> bool:

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -13,8 +13,12 @@ def get_versionable_item(cms_config) -> type | None:
             from djangocms_versioning.datastructures import VersionableItem
 
             return VersionableItem
-        except ImportError:
-            return None
+        except ModuleNotFoundError as exc:
+            # Only treat a missing djangocms_versioning module as "no versioning";
+            # re-raise for any other import issue so real errors are not hidden.
+            if exc.name in ("djangocms_versioning.datastructures", "djangocms_versioning"):
+                return None
+            raise
     return None
 
 

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -12,6 +12,7 @@ def get_versionable_item(cms_config) -> type | None:
         # Pre django CMS 5.1
         try:
             from djangocms_versioning.datastructure import VersionableItem
+
             raise ImportError("djangocms_versioning is not installed")
         except ImportError:
             return None

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -1,9 +1,12 @@
 from importlib import reload
+from unittest import skipIf, skipUnless
 
+from django.apps import apps
 from django.conf import settings
 from django.test import TestCase, override_settings
 
 from djangocms_alias import cms_config
+from djangocms_alias.utils import get_versionable_item, is_versioning_enabled
 
 
 class ReferenceConfigTestCase(TestCase):
@@ -27,3 +30,28 @@ class ReferenceConfigTestCase(TestCase):
         del settings.REFERENCES_ALIAS_MODELS_ENABLED
         reload(cms_config)
         self.assertTrue(cms_config.AliasCMSConfig.djangocms_references_enabled)
+
+
+class GetVersionableItemTestCase(TestCase):
+    def setUp(self):
+        get_versionable_item.cache_clear()
+
+    def tearDown(self):
+        get_versionable_item.cache_clear()
+
+    @skipUnless(is_versioning_enabled(), "Test only relevant when versioning is installed")
+    def test_returns_versionable_item_when_versioning_installed(self):
+        from djangocms_versioning.datastructures import VersionableItem
+
+        alias_cms_config = apps.get_app_config("djangocms_alias").cms_config
+        result = get_versionable_item(alias_cms_config)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(issubclass(result, VersionableItem) or result is VersionableItem)
+
+    @skipIf(is_versioning_enabled(), "Test only relevant when versioning is not installed")
+    def test_returns_none_when_versioning_not_installed(self):
+        alias_cms_config = apps.get_app_config("djangocms_alias").cms_config
+        result = get_versionable_item(alias_cms_config)
+
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary by Sourcery

Adjust alias versioning detection and expand tests around versioning behavior.

Bug Fixes:
- Ensure `get_versionable_item` correctly identifies djangocms-versioning even if versioning contract is not available
- Ensure `get_versionable_item` correctly handles projects with and without djangocms_versioning installed.

Tests:
- Add test coverage for get_versionable_item to verify behavior when versioning is installed and when it is not.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #368 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

Fix alias versioning detection and add tests to cover behavior with and without djangocms-versioning installed.

Bug Fixes:
- Correct get_versionable_item to detect djangocms-versioning installations even when the versioning contract API is unavailable.

Tests:
- Add unit tests for get_versionable_item to verify behavior when djangocms-versioning is installed and when it is not.