### PR TITLE
feat: Clearer overview of alias usages in both the usage and delete view

### DIFF
--- a/djangocms_alias/admin.py
+++ b/djangocms_alias/admin.py
@@ -7,6 +7,7 @@ from cms.utils.permissions import get_model_permission_codename
 from cms.utils.urlutils import admin_reverse
 from django import forms
 from django.contrib import admin, messages
+from django.contrib.admin.utils import unquote
 from django.db import models
 from django.http import (
     Http404,
@@ -30,6 +31,7 @@ from .models import Alias, AliasContent, Category
 from .utils import (
     emit_content_change,
     emit_content_delete,
+    get_alias_usage_context,
     is_versioning_enabled,
 )
 
@@ -120,6 +122,13 @@ class AliasAdmin(GrouperModelAdmin):
                 )
             return request.user.is_superuser
         return True
+
+    def delete_view(self, request: HttpRequest, object_id: str, extra_context: dict = None):
+        obj = self.get_object(request, unquote(object_id))
+        if obj:
+            # Same usage listing as the alias usage view
+            extra_context = {**(extra_context or {}), **get_alias_usage_context(obj)}
+        return super().delete_view(request, object_id, extra_context)
 
     def save_model(self, request: HttpRequest, obj: Alias, form: forms.Form, change: bool) -> None:
         super().save_model(request, obj, form, change)

--- a/djangocms_alias/cms_plugins.py
+++ b/djangocms_alias/cms_plugins.py
@@ -1,4 +1,3 @@
-from cms.models import Page
 from cms.plugin_base import CMSPluginBase, PluginMenuItem
 from cms.plugin_pool import plugin_pool
 from cms.toolbar.utils import get_object_edit_url, get_plugin_toolbar_info, get_plugin_tree
@@ -19,7 +18,7 @@ from django.utils.translation import (
 )
 
 from djangocms_alias import constants
-from djangocms_alias.utils import emit_content_change, get_current_site
+from djangocms_alias.utils import emit_content_change, get_alias_usage_context, get_current_site
 
 from . import views
 from .constants import CREATE_ALIAS_URL_NAME, DETACH_ALIAS_PLUGIN_URL_NAME
@@ -388,11 +387,6 @@ class Alias(CMSPluginBase):
             "title": title,
             "original": title,
             "show_back_btn": request.GET.get("back"),
-            "objects_list": sorted(
-                alias.objects_using,
-                # First show Pages on list
-                key=lambda obj: isinstance(obj, Page),
-                reverse=True,
-            ),
+            **get_alias_usage_context(alias),
         }
         return TemplateResponse(request, "djangocms_alias/alias_usage.html", context)

--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -2,7 +2,7 @@ import operator
 from collections import defaultdict
 
 from cms.api import add_plugin
-from cms.models import CMSPlugin, Placeholder
+from cms.models import CMSPlugin, Page, Placeholder
 from cms.models.fields import PlaceholderRelationField
 from cms.models.managers import ContentAdminManager, WithUserMixin
 from cms.utils.permissions import get_model_permission_codename
@@ -10,6 +10,7 @@ from cms.utils.plugins import copy_plugins_to_placeholder
 from cms.utils.urlutils import admin_reverse
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models, transaction
 from django.db.models import F, Q
 from django.utils.encoding import force_str
@@ -129,31 +130,73 @@ class Alias(models.Model):
 
     @cached_property
     def objects_using(self):
-        objects = set()
-        object_ids = defaultdict(set)
         plugins = self.cms_plugins.select_related("placeholder").prefetch_related("placeholder__source")
+        # The prefetch fetches the placeholder sources in one query per content type
+        sources_by_type = defaultdict(list)
+        hidden_placeholders = {}
         for plugin in plugins:
             obj = plugin.placeholder.source
-
-            # Skip plugins that have no placeholder source e.g clipboard
             if obj is None:
-                continue
-
-            obj_class_name = obj.__class__.__name__
-            if obj_class_name.endswith("Content"):
-                attr_name = obj_class_name.replace("Content", "").lower()
-                attr_related_model = obj._meta.get_field(attr_name).related_model
-                id_attr = getattr(obj, f"{attr_name}_id")
-                if id_attr:
-                    object_ids[attr_related_model].update([id_attr])
-                else:
-                    objects.update([obj])
+                # Plugins on placeholders without a source, e.g. the clipboard
+                # or orphaned placeholders - they block deletion but have no
+                # object to show, so the usage view lists them separately
+                hidden_placeholders.setdefault(plugin.placeholder_id, plugin.placeholder)
             else:
-                objects.update([obj])
-        objects.update(
-            [obj for model_class, ids in object_ids.items() for obj in model_class.objects.filter(pk__in=ids)]
-        )
+                sources_by_type[type(obj)].append(obj)
+        self._hidden_usages = list(hidden_placeholders.values())
+
+        objects = set()
+        contents_by_grouper = defaultdict(lambda: defaultdict(list))
+        for model, sources in sources_by_type.items():
+            grouper_field = None
+            if model.__name__.endswith("Content"):
+                try:
+                    grouper_field = model._meta.get_field(model.__name__.removesuffix("Content").lower())
+                except FieldDoesNotExist:
+                    pass
+            if grouper_field is None:
+                # Not a content model - the source itself is the object using the alias
+                objects.update(sources)
+                continue
+            for obj in sources:
+                grouper_id = getattr(obj, grouper_field.attname)
+                if grouper_id:
+                    contents_by_grouper[grouper_field.related_model][grouper_id].append(obj)
+                else:
+                    objects.add(obj)
+        for grouper_model, contents_by_id in contents_by_grouper.items():
+            # One query per grouper model fetches all groupers of that type
+            queryset = grouper_model.objects.filter(pk__in=contents_by_id)
+            if issubclass(grouper_model, Page):
+                # Page.__str__ renders title and path - batch-fetch what it
+                # reads so the usage list does not query per page
+                queryset = queryset.prefetch_related("pagecontent_set", "urls")
+            groupers = list(queryset)
+            if issubclass(grouper_model, Alias):
+                self._prefill_content_caches(groupers)
+            for grouper in groupers:
+                # The content objects through which this alias references the
+                # grouper - they exist even when the grouper has no URL in the
+                # current language (e.g. unpublished or untranslated pages)
+                grouper._using_contents = contents_by_id[grouper.pk]
+                objects.add(grouper)
         return list(objects)
+
+    @staticmethod
+    def _prefill_content_caches(aliases):
+        """Batch-fill the per-instance content cache that get_name reads,
+        mirroring what get_content(show_draft_content=True) would cache."""
+        contents = AliasContent.admin_manager.filter(alias__in=aliases).latest_content()
+        contents_by_alias = defaultdict(list)
+        for content in contents:
+            contents_by_alias[content.alias_id].append(content)
+        language = get_language()
+        for alias in aliases:
+            for content in contents_by_alias[alias.pk]:
+                alias._content_cache.setdefault(content.language, content)
+            # Cache "no content" for the current language like get_content
+            # does, so aliases without a translation do not re-query
+            alias._content_cache.setdefault(language, None)
 
     def get_name(self, language=None):
         content = self.get_content(language, show_draft_content=True)

--- a/djangocms_alias/models.py
+++ b/djangocms_alias/models.py
@@ -153,6 +153,8 @@ class Alias(models.Model):
                 try:
                     grouper_field = model._meta.get_field(model.__name__.removesuffix("Content").lower())
                 except FieldDoesNotExist:
+                    # Named *Content but without a grouper relation - fall
+                    # through and treat the source itself as the using object
                     pass
             if grouper_field is None:
                 # Not a content model - the source itself is the object using the alias

--- a/djangocms_alias/templates/admin/djangocms_alias/alias/delete_confirmation.html
+++ b/djangocms_alias/templates/admin/djangocms_alias/alias/delete_confirmation.html
@@ -1,10 +1,16 @@
 {% extends "admin/delete_confirmation.html" %}
 {% load i18n static admin_urls cms_tags djangocms_alias_tags %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'admin/css/changelists.css' %}">
+{% endblock %}
+
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
     <script src="{% static 'admin/js/cancel.js' %}" async></script>
+    <script src="{% static 'cms/js/admin/actions.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumbs %}{% endblock %}
@@ -19,16 +25,9 @@
 </p>
 
 
-{% if object.objects_using %}
-  {% blocktrans with escaped_object=object %}This alias is used by following objects:{% endblocktrans %}
-  <ul>
-      {% for item in object.objects_using %}
-      <li>
-          {{ item|verbose_name|capfirst|escape }}:
-          {% if item|admin_view_url %}<a href="{{ item|admin_view_url }}">{{ item }}</a>{% else %}{{ item }}{% endif %}
-      </li>
-      {% endfor %}
-  </ul>
+{% if objects_list or hidden_usages %}
+  <p>{% blocktrans with escaped_object=object %}This alias is used by following objects:{% endblocktrans %}</p>
+  {% include "djangocms_alias/includes/usage_results.html" %}
 {% else %}
   <p>{% blocktrans with escaped_object=object %}This alias is not used by any object.{% endblocktrans %}</p>
 {% endif %}

--- a/djangocms_alias/templates/djangocms_alias/alias_usage.html
+++ b/djangocms_alias/templates/djangocms_alias/alias_usage.html
@@ -1,14 +1,17 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls cms_tags djangocms_alias_tags %}
+{% load i18n admin_urls static cms_tags djangocms_alias_tags %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/changelists.css' %}">
+{% endblock %}
 
 {% block extrahead %}{{ block.super }}
-<script>
-    function closeSideframe() {
-        try {
-            window.top.CMS.$('.cms-sideframe-close').trigger('click.cms.sideframe');
-        } catch(e) {}
-    }
-</script>
+<script src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+<script src="{% static 'admin/js/jquery.init.js' %}"></script>
+<script src="{% static 'cms/js/admin/actions.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -23,37 +26,8 @@
 
 
 {% block content %}
-{% if show_back_btn %}<a href="javascript:history.back()" class="button cancel-link cms-btn">{% trans "Back" %}</a>{% endif %}
-<div class="results">
-    <table id="result_list">
-        <thead>
-            <tr>
-                <th>{% trans 'Type' %}</th>
-                <th>{% trans 'Name' %}</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for item in objects_list %}
-            <tr>
-                {% with item|verbose_name as object_type %}
-                <td>{{ object_type|capfirst|escape }}</td>
-                <td>
-                  {% if item|admin_view_url %}
-                    <a target="_top" onclick="closeSideframe()" href="{{ item|admin_view_url }}">{{ item }}</a>
-                  {% else %}
-                    {{ item }}
-                  {% endif %}
-                </td>
-                <td>
-                    {% if object_type == 'alias' %}
-                    <a href="{% get_alias_usage_view_url alias=item back=1 %}">{% trans 'View usage' %}</a>
-                    {% endif %}
-                </td>
-                {% endwith %}
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+<div id="content-main">
+    {% if show_back_btn %}<a href="javascript:history.back()" class="button cancel-link cms-btn">{% trans "Back" %}</a>{% endif %}
+    {% include "djangocms_alias/includes/usage_results.html" %}
 </div>
 {% endblock content %}

--- a/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
+++ b/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
@@ -1,0 +1,65 @@
+{% load i18n djangocms_alias_tags %}
+{% comment %}
+Changelist-style listing of the objects using an alias. Expects
+``objects_list`` and ``hidden_usages`` in the context (see
+djangocms_alias.utils.get_alias_usage_context).
+{% endcomment %}
+<div class="module" id="changelist">
+    <div class="results">
+        <table id="result_list">
+            <thead>
+                <tr>
+                    <th scope="col" class="column-type">
+                        <div class="text"><span>{% trans 'Type' %}</span></div>
+                        <div class="clear"></div>
+                    </th>
+                    <th scope="col" class="column-name">
+                        <div class="text"><span>{% trans 'Name' %}</span></div>
+                        <div class="clear"></div>
+                    </th>
+                    <th scope="col" class="column-actions">
+                        <div class="text"><span>&nbsp;</span></div>
+                        <div class="clear"></div>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in objects_list %}
+                <tr>
+                    {% with item|verbose_name as object_type %}
+                    <td class="field-type">{{ object_type|capfirst|escape }}</td>
+                    <th class="field-name">
+                      {% if item|admin_view_url %}
+                        <a target="_top" class="js-close-sideframe" href="{{ item|admin_view_url }}">{{ item }}</a>
+                      {% else %}
+                        {{ item }}
+                      {% endif %}
+                    </th>
+                    <td class="field-actions">
+                        {% if object_type == 'alias' %}
+                        <a href="{% get_alias_usage_view_url alias=item back=1 %}">{% trans 'View usage' %}</a>
+                        {% endif %}
+                    </td>
+                    {% endwith %}
+                </tr>
+                {% endfor %}
+                {% for placeholder in hidden_usages %}
+                <tr>
+                    <td class="field-type">{{ placeholder|verbose_name|capfirst|escape }}</td>
+                    <th class="field-name">{{ placeholder }} <em>({% trans 'hidden usage, e.g. clipboard content or an orphaned placeholder' %})</em></th>
+                    <td class="field-actions"></td>
+                </tr>
+                {% endfor %}
+                {% if not objects_list and not hidden_usages %}
+                <tr>
+                    <td colspan="3">{% trans 'This alias is not used by any object.' %}</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+    <p class="paginator">
+        {% blocktrans count counter=objects_list|length %}{{ counter }} object{% plural %}{{ counter }} objects{% endblocktrans %}{% if hidden_usages %},
+        {% blocktrans count counter=hidden_usages|length %}{{ counter }} hidden usage{% plural %}{{ counter }} hidden usages{% endblocktrans %}{% endif %}
+    </p>
+</div>

--- a/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
+++ b/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
@@ -29,11 +29,22 @@ djangocms_alias.utils.get_alias_usage_context).
                     {% with item|verbose_name as object_type %}
                     <td class="field-type">{{ object_type|capfirst|escape }}</td>
                     <th class="field-name">
-                      {% if item|admin_view_url %}
+                      {% with item|using_contents as contents %}
+                      {% if contents|length > 1 %}
+                        <details class="usage-contents">
+                            <summary>{{ item }}</summary>
+                            <ul>
+                                {% for content in contents %}
+                                <li><a target="_top" class="js-close-sideframe" href="{{ content|admin_view_url }}">{{ content }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </details>
+                      {% elif item|admin_view_url %}
                         <a target="_top" class="js-close-sideframe" href="{{ item|admin_view_url }}">{{ item }}</a>
                       {% else %}
                         {{ item }}
                       {% endif %}
+                      {% endwith %}
                     </th>
                     <td class="field-actions">
                         {% if object_type == 'alias' %}

--- a/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
+++ b/djangocms_alias/templates/djangocms_alias/includes/usage_results.html
@@ -26,8 +26,7 @@ djangocms_alias.utils.get_alias_usage_context).
             <tbody>
                 {% for item in objects_list %}
                 <tr>
-                    {% with item|verbose_name as object_type %}
-                    <td class="field-type">{{ object_type|capfirst|escape }}</td>
+                    <td class="field-type">{{ item|verbose_name|capfirst|escape }}</td>
                     <th class="field-name">
                       {% with item|using_contents as contents %}
                       {% if contents|length > 1 %}
@@ -47,11 +46,10 @@ djangocms_alias.utils.get_alias_usage_context).
                       {% endwith %}
                     </th>
                     <td class="field-actions">
-                        {% if object_type == 'alias' %}
+                        {% if item|model_name == 'alias' %}
                         <a href="{% get_alias_usage_view_url alias=item back=1 %}">{% trans 'View usage' %}</a>
                         {% endif %}
                     </td>
-                    {% endwith %}
                 </tr>
                 {% endfor %}
                 {% for placeholder in hidden_usages %}

--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -73,6 +73,12 @@ def verbose_name(obj) -> str:
     return obj._meta.verbose_name
 
 
+@register.filter()
+def model_name(obj) -> str:
+    """Stable, non-localized model identifier for template conditions."""
+    return obj._meta.model_name
+
+
 @register.simple_tag(takes_context=True)
 def render_alias(context, instance) -> str:
     request = context["request"]

--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -10,6 +10,7 @@ from cms.utils.placeholder import validate_placeholder_name
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 from django import template
 from django.conf import settings
+from django.utils.translation import get_language
 
 from ..constants import DEFAULT_STATIC_ALIAS_CATEGORY_NAME, USAGE_ALIAS_URL_NAME
 from ..models import Alias, AliasContent, Category
@@ -33,13 +34,20 @@ def admin_view_url(obj) -> str:
     if obj and is_editable_model(obj.__class__):
         # Is obj frontend-editable?
         return get_object_preview_url(obj)
+    contents = getattr(obj, "_using_contents", None)
+    if contents:
+        # Content objects collected by Alias.objects_using - their preview
+        # endpoint works regardless of admin language or publication state
+        language = get_language()
+        content_obj = next((c for c in contents if getattr(c, "language", None) == language), contents[0])
+        return get_object_preview_url(content_obj)
     if hasattr(obj, "get_content"):
         # Is its content object frontend-editable?
         content_obj = obj.get_content()
         if content_obj and is_editable_model(content_obj.__class__):
             return get_object_preview_url(content_obj)
     if hasattr(obj, "get_absolute_url"):
-        return obj.get_absolute_url()
+        return obj.get_absolute_url() or ""
     return ""
 
 

--- a/djangocms_alias/templatetags/djangocms_alias_tags.py
+++ b/djangocms_alias/templatetags/djangocms_alias_tags.py
@@ -29,17 +29,34 @@ def get_alias_usage_view_url(alias, **kwargs) -> str:
     return add_url_parameters(url, **ChainMap(kwargs))
 
 
+def _using_contents_by_language(obj) -> dict:
+    """The content objects collected by Alias.objects_using, newest one per
+    language (versioning copies plugins into every version of a content)."""
+    by_language = {}
+    for content in getattr(obj, "_using_contents", []):
+        language = getattr(content, "language", None)
+        newest = by_language.get(language)
+        if newest is None or (content.pk or 0) > (newest.pk or 0):
+            by_language[language] = content
+    return by_language
+
+
+@register.filter()
+def using_contents(obj) -> list:
+    """One content object per language through which obj uses the alias."""
+    return list(_using_contents_by_language(obj).values())
+
+
 @register.filter()
 def admin_view_url(obj) -> str:
     if obj and is_editable_model(obj.__class__):
         # Is obj frontend-editable?
         return get_object_preview_url(obj)
-    contents = getattr(obj, "_using_contents", None)
+    contents = _using_contents_by_language(obj)
     if contents:
         # Content objects collected by Alias.objects_using - their preview
         # endpoint works regardless of admin language or publication state
-        language = get_language()
-        content_obj = next((c for c in contents if getattr(c, "language", None) == language), contents[0])
+        content_obj = contents.get(get_language()) or next(iter(contents.values()))
         return get_object_preview_url(content_obj)
     if hasattr(obj, "get_content"):
         # Is its content object frontend-editable?

--- a/djangocms_alias/utils.py
+++ b/djangocms_alias/utils.py
@@ -41,6 +41,24 @@ def is_versioning_enabled() -> bool:
     return bool(getattr(cms_config, "versioning", False))
 
 
+def get_alias_usage_context(alias) -> dict:
+    """Common template context for the usage and delete confirmation views."""
+    from cms.models import Page
+
+    objects_list = sorted(
+        alias.objects_using,
+        # First show Pages on list
+        key=lambda obj: isinstance(obj, Page),
+        reverse=True,
+    )
+    return {
+        "objects_list": objects_list,
+        # Usages without a visible object (e.g. clipboard content or orphaned
+        # placeholders) - set by accessing objects_using above
+        "hidden_usages": getattr(alias, "_hidden_usages", []),
+    }
+
+
 def emit_content_change(objs, sender=None):
     try:
         from djangocms_internalsearch.helpers import emit_content_change

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -257,7 +257,8 @@ class AliasModelsTestCase(BaseAliasPluginTestCase):
         self.add_alias_plugin_to_page(site2_page, alias, "en")
         # Should show on the list only once
 
-        with self.assertNumQueries(3):
+        # plugins, sources, pages + 2 batched prefetches (page contents, urls)
+        with self.assertNumQueries(5):
             objects = alias.objects_using
 
         self.assertEqual(
@@ -338,28 +339,29 @@ class AliasModelsTestCase(BaseAliasPluginTestCase):
             alias=alias4,
         )
 
-        with self.assertNumQueries(3):
+        # plugins, sources, aliases + 1 batched content-cache prefill
+        with self.assertNumQueries(4):
             objects = alias1.objects_using
         self.assertEqual(
             sorted(obj.pk for obj in objects),
             [root_alias.pk],
         )
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             objects = alias2.objects_using
         self.assertEqual(
             sorted(obj.pk for obj in objects),
             [root_alias.pk, root_alias2.pk],
         )
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             objects = alias3.objects_using
         self.assertEqual(
             sorted(obj.pk for obj in objects),
             [alias2.pk],
         )
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             objects = alias4.objects_using
         self.assertEqual(
             sorted(obj.pk for obj in objects),
@@ -376,7 +378,8 @@ class AliasModelsTestCase(BaseAliasPluginTestCase):
             alias=alias,
         )
         self.add_alias_plugin_to_page(self.page, alias, "en")
-        with self.assertNumQueries(5):
+        # plugins, 2 source types, 2 grouper fetches + 3 batched prefetches
+        with self.assertNumQueries(8):
             objects = alias.objects_using
         self.assertEqual(
             sorted(obj.pk for obj in objects),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -863,8 +863,8 @@ class AliasViewsTestCase(BaseAliasPluginTestCase):
                 ),
             )
 
-        self.assertContains(response, "<td>Page</td>")
-        self.assertNotContains(response, "<td>Alias</td>")
+        self.assertContains(response, '<td class="field-type">Page</td>')
+        self.assertNotContains(response, '<td class="field-type">Alias</td>')
 
         add_plugin(
             root_alias.get_placeholder(self.language),
@@ -881,11 +881,12 @@ class AliasViewsTestCase(BaseAliasPluginTestCase):
                 ),
             )
 
-        self.assertContains(response, "<td>Page</td>")
-        self.assertContains(response, "<td>Alias</td>")
+        self.assertContains(response, '<td class="field-type">Page</td>')
+        self.assertContains(response, '<td class="field-type">Alias</td>')
         self.assertRegex(
             str(response.content),
-            rf'href="{re.escape(self.page.get_absolute_url(self.language))}"[\w+]?>{re.escape(str(self.page))}<\/a>',
+            rf'href="{re.escape(get_object_preview_url(self.page.get_admin_content(self.language)))}"'
+            rf"[\w+]?>{re.escape(str(self.page))}<\/a>",
         )
         self.assertRegex(
             str(response.content),
@@ -906,6 +907,28 @@ class AliasViewsTestCase(BaseAliasPluginTestCase):
                 "View usage",
             ),
         )
+
+    def test_alias_usage_view_shows_hidden_usages(self):
+        alias = self._create_alias()
+        # A plugin on a placeholder without a source, like the clipboard,
+        # blocks deletion but has no object to list
+        placeholder = Placeholder.objects.create(slot="clipboard")
+        add_plugin(
+            placeholder,
+            "Alias",
+            language=self.language,
+            alias=alias,
+        )
+        with self.login_user_context(self.superuser):
+            response = self.client.get(
+                admin_reverse(
+                    USAGE_ALIAS_URL_NAME,
+                    args=[alias.pk],
+                ),
+            )
+
+        self.assertContains(response, "hidden usage")
+        self.assertContains(response, "clipboard")
 
     def test_delete_alias_view_get(self):
         alias = self._create_alias([self.plugin])
@@ -957,9 +980,10 @@ class AliasViewsTestCase(BaseAliasPluginTestCase):
                 ),
             )
         self.assertContains(response, "This alias is used by following objects:")
+        self.assertContains(response, '<td class="field-type">Page</td>')
         test = (
-            rf"<li>[\s\\n]*Page:[\s\\n]*<a href=\"{re.escape(self.page.get_absolute_url(self.language))}\">"
-            rf"{re.escape(str(self.page))}<\/a>[\s\\n]*<\/li>"
+            rf"<a[^>]*href=\"{re.escape(get_object_preview_url(self.page.get_admin_content(self.language)))}\""
+            rf"[^>]*>{re.escape(str(self.page))}<\/a>"
         )
         self.assertRegex(str(response.content), test)
 


### PR DESCRIPTION
## Summary by Sourcery

Unify and enhance alias usage listing in both the usage and delete views to provide clearer, changelist-style overviews, including hidden usages and better preview links.

New Features:
- Add shared changelist-style template for displaying objects that use an alias, including counts and hidden usages such as clipboard or orphaned placeholders.
- Expose per-language content usages and preview links via new template filters to show how objects reference an alias.
- Provide a common helper to build alias usage context so both usage and delete views show consistent information.

Enhancements:
- Refine Alias.objects_using to group content by grouper models, prefetch related data, handle content/grouper relationships more efficiently, and capture hidden placeholder usages.
- Improve admin usage and delete templates by loading standard admin assets, aligning markup with Django changelists, and wiring CMS admin actions for closing sideframes.
- Enhance alias admin delete view to inject usage context, reusing the same listing as the usage view.

Tests:
- Update existing alias usage and delete view tests to reflect the new markup and preview URL behavior, and add coverage for displaying hidden usages and adjusted query counts in objects_using.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #376 
* fixes #375 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)